### PR TITLE
Whitelist X-Forwarded-For on all requests

### DIFF
--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -303,12 +303,15 @@ BANNED_IP_RANGES = [
 ]
 
 # Trusted Proxies (opt in)
-# If true, IP-examining functions should reject requests from anyone except trusted proxies
+# If true, wsgi.py will reject requests from anyone except trusted proxies
 LIMIT_TO_TRUSTED_PROXY = False
+# Trusted proxies should be a list of reverse proxies in the chain, where each proxy is a list of whitelisted IP ranges
+# for that proxy. For example:
+# TRUSTED_PROXIES = [['<cloudflare range>', '<cloudflare range>'], ['<nginx server ip>']]
 TRUSTED_PROXIES = []
-# If LIMIT_TO_TRUSTED_PROXY is True, this is the only http header we will use to
-# determine/test/validate a client's IP address.
-TRUSTED_PROXY_HEADER = ''
+
+# Http header we will use to determine/test/validate a client's IP address.
+CLIENT_IP_HEADER = 'REMOTE_ADDR'
 
 # Celery settings
 BROKER_URL = 'amqp://guest:guest@localhost:5672/'

--- a/perma_web/perma/tests/test_utils.py
+++ b/perma_web/perma/tests/test_utils.py
@@ -1,4 +1,3 @@
-from django.test import override_settings
 from django.test.client import RequestFactory
 
 from perma.utils import *
@@ -10,47 +9,6 @@ class UtilsTestCase(PermaTestCase):
     def setUp(self):
         self.factory = RequestFactory()
 
-    @override_settings(LIMIT_TO_TRUSTED_PROXY=True,
-                   TRUSTED_PROXIES = ["10.0.2.2"],
-                   TRUSTED_PROXY_HEADER = 'REMOTE_ADDR')
-    def test_get_client_ip_wrong_proxy(self):
-        request = self.factory.get('/some/route', REMOTE_ADDR="127.0.0.1")
-        with self.assertRaises(PermissionDenied):
-            get_client_ip(request)
-
-    @override_settings(LIMIT_TO_TRUSTED_PROXY=True,
-                   TRUSTED_PROXIES = ["10.0.2.2"],
-                   TRUSTED_PROXY_HEADER = 'REMOTE_ADDR')
-    def test_get_client_ip_right_proxy(self):
-        request = self.factory.get('/some/route', REMOTE_ADDR="10.0.2.2")
-        self.assertEqual(get_client_ip(request), "10.0.2.2")
-
-    @override_settings(LIMIT_TO_TRUSTED_PROXY=True,
-                   TRUSTED_PROXIES = ["10.0.2.2"],
-                   TRUSTED_PROXY_HEADER = 'REMOTE_ADDR')
-    def test_get_client_ip_wrong_header(self):
-        request = self.factory.get('/some/route', HTTP_X_FORWARDED_FOR="10.0.2.2")
-        with self.assertRaises(PermissionDenied):
-            get_client_ip(request)
-
-    @override_settings(LIMIT_TO_TRUSTED_PROXY=False,
-                   TRUSTED_PROXIES = ["10.0.2.2"],
-                   TRUSTED_PROXY_HEADER = 'REMOTE_ADDR')
-    def test_get_client_ip_no_checking_remote_only(self):
-        request = self.factory.get('/some/route', REMOTE_ADDR="127.0.0.1")
-        self.assertEqual(get_client_ip(request), "127.0.0.1")
-
-    @override_settings(LIMIT_TO_TRUSTED_PROXY=False,
-                   TRUSTED_PROXIES = ["10.0.2.2"],
-                   TRUSTED_PROXY_HEADER = 'REMOTE_ADDR')
-    def test_get_client_ip_no_checking_xforwarded_only(self):
-        request = self.factory.get('/some/route', HTTP_X_FORWARDED_FOR="127.0.0.1")
-        self.assertEqual(get_client_ip(request), "127.0.0.1")
-
-    @override_settings(LIMIT_TO_TRUSTED_PROXY=False,
-                   TRUSTED_PROXIES = ["10.0.2.2"],
-                   TRUSTED_PROXY_HEADER = 'REMOTE_ADDR')
-    def test_get_client_ip_no_checking_xforwarded_prefered(self):
-        request = self.factory.get('/some/route', HTTP_X_FORWARDED_FOR="10.0.2.2", REMOTE_ADDR="127.0.0.1")
-        self.assertEqual(get_client_ip(request), "10.0.2.2")
-
+    def test_get_client_ip(self):
+        request = self.factory.get('/some/route', REMOTE_ADDR="1.2.3.4")
+        self.assertEqual(get_client_ip(request), "1.2.3.4")

--- a/perma_web/perma/tests/test_wsgi.py
+++ b/perma_web/perma/tests/test_wsgi.py
@@ -1,0 +1,61 @@
+import requests
+
+from django.test import LiveServerTestCase
+
+import perma.settings
+import perma.wsgi
+
+
+class WsgiTestCase(LiveServerTestCase):
+
+    def setUp(self):
+        # Set custom settings and reload wsgi app.
+        # We have to override settings in this weird way -- by monkeypatching perma.settings and reloading wsgi.py --
+        # because wsgi.py is designed to run before django is loaded.
+        self.orig_LIMIT_TO_TRUSTED_PROXY = perma.settings.LIMIT_TO_TRUSTED_PROXY
+        perma.settings.LIMIT_TO_TRUSTED_PROXY = True
+        self.orig_TRUSTED_PROXIES = perma.settings.TRUSTED_PROXIES
+        perma.settings.TRUSTED_PROXIES = [["1.2.0.0/16", "3.4.0.0/16"],["127.0.0.1,5.6/16"]]
+        reload(perma.wsgi)
+
+        # use full wsgi app in test server
+        self.server_thread.httpd.set_app(self.server_thread.static_handler(perma.wsgi.application))
+
+    def tearDown(self):
+        # Make sure we leave everything like we found it.
+        perma.settings.LIMIT_TO_TRUSTED_PROXY = self.orig_LIMIT_TO_TRUSTED_PROXY
+        perma.settings.TRUSTED_PROXIES = self.orig_TRUSTED_PROXIES
+        reload(perma.wsgi)
+
+    def test_get_client_ip_no_proxy(self):
+        # No X-Forwarded-For header:
+        response = requests.get(self.live_server_url)
+        self.assertEqual(response.status_code, 400)
+
+    def test_get_client_ip_short_proxy(self):
+        # Incomplete proxy chain:
+        response = requests.get(self.live_server_url, headers={
+            'X-Forwarded-For': '1.1.1.1,127.0.0.1'  #<client IP>,<final IP>
+        })
+        self.assertEqual(response.status_code, 400)
+
+    def test_get_client_ip_wrong_proxy(self):
+        # Complete proxy chain, but one proxy is wrong:
+        response = requests.get(self.live_server_url, headers={
+            'X-Forwarded-For': '1.1.1.1,8.8.8.8,127.0.0.1'  #<client IP>,<wrong IP>,<right IP>
+        })
+        self.assertEqual(response.status_code, 400)
+
+    def test_get_client_ip_wrong_remote_addr(self):
+        # Valid proxy chain, but REMOTE_ADDR doesn't match the final proxy:
+        response = requests.get(self.live_server_url, headers={
+            'X-Forwarded-For': '1.1.1.1,1.2.3.4,5.6.7.8'  #<client IP>,<right IP>,<mismatched valid IP>
+        })
+        self.assertEqual(response.status_code, 400)
+
+    def test_get_client_ip_right_proxy(self):
+        # Valid proxy chain:
+        response = requests.get(self.live_server_url, headers={
+            'X-Forwarded-For': '1.1.1.1,1.2.3.4,127.0.0.1'  #<client IP>,<right IP>,<right IP>
+        })
+        self.assertEqual(response.status_code, 200)

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -233,13 +233,4 @@ def url_in_allowed_ip_range(url):
     return ip_in_allowed_ip_range(ip)
 
 def get_client_ip(request):
-    if settings.LIMIT_TO_TRUSTED_PROXY:
-        proxy_ip = IPAddress(request.META['REMOTE_ADDR'])
-        if any(proxy_ip in IPNetwork(trusted_ip_range) for trusted_ip_range in settings.TRUSTED_PROXIES):
-            try:
-                return request.META[settings.TRUSTED_PROXY_HEADER]
-            except KeyError:
-                raise PermissionDenied
-        raise PermissionDenied
-    else:
-        return request.META.get('HTTP_X_FORWARDED_FOR', request.META['REMOTE_ADDR'])
+    return request.META[settings.CLIENT_IP_HEADER]

--- a/perma_web/perma/wsgi.py
+++ b/perma_web/perma/wsgi.py
@@ -27,6 +27,7 @@ from werkzeug.wsgi import DispatcherMiddleware
 from django.core.wsgi import get_wsgi_application
 from warc_server.app import application as warc_application
 
+# Pywb request rewriting for the /timegate route
 class PywbRedirectMiddleware(object):
     def __init__(self, pywb):
         self.pywb = pywb
@@ -53,7 +54,8 @@ if perma.settings.USE_OPBEAT:
         )
     )
 
-# set up application
+
+# Main application setup
 application = DispatcherMiddleware(
     get_wsgi_application(),  # Django app
     {
@@ -61,6 +63,45 @@ application = DispatcherMiddleware(
         perma.settings.WARC_ROUTE: warc_application,  # pywb for record playback
     }
 )
+
+# Middleware to whitelist X-Forwarded-For proxy IP addresses
+if perma.settings.LIMIT_TO_TRUSTED_PROXY:
+    from netaddr import IPNetwork
+    from werkzeug.wrappers import Response
+    class ForwardedForWhitelistMiddleware(object):
+
+        def __init__(self, app, whitelists, header='HTTP_X_FORWARDED_FOR'):
+            self.app = app
+            self.header = header
+            self.whitelists = [[IPNetwork(trusted_ip_range) for trusted_ip_range in whitelist] for whitelist in whitelists]
+
+        def bad_request(self, environ, start_response, reason=''):
+            response = Response(reason, 400)
+            return response(environ, start_response)
+
+        def __call__(self, environ, start_response):
+            # Parse X-Forwarded-For header into list of IPs.
+            # First IP in list is client IP, then each proxy up to the closest one.
+            forwarded_for_header = environ.get(self.header, '')
+            proxy_ips = [x for x in [x.strip() for x in forwarded_for_header.split(',')] if x]
+
+            # List must include, at least, client IP plus one IP per proxy in our whitelists.
+            if len(proxy_ips) < len(self.whitelists) + 1:
+                return self.bad_request(environ, start_response)  #, 'Header %s has insufficient entries' % self.header)
+
+            # Final proxy in list must match REMOTE_ADDR environment variable.
+            if proxy_ips[-1] != environ.get('REMOTE_ADDR', ''):
+                return self.bad_request(environ, start_response)  #, 'Header %s must match remote_addr' % self.header)
+
+            # Each of the final IPs in the list must match the relevant whitelist.
+            for whitelist, proxy_ip in zip(self.whitelists, proxy_ips[-len(self.whitelists):]):
+                if not any(proxy_ip in trusted_ip_range for trusted_ip_range in whitelist):
+                    return self.bad_request(environ, start_response)  #, 'Header %s has invalid proxy IP. Value: %s' % (self.header, forwarded_for_header))
+
+            # All whitelists passed!
+            return self.app(environ, start_response)
+
+    application = ForwardedForWhitelistMiddleware(application, whitelists=perma.settings.TRUSTED_PROXIES)
 
 # add newrelic app wrapper
 if use_newrelic:


### PR DESCRIPTION
How does this strike you?

- Whitelist all requests via wsgi middleware
- Whitelist each hop in the X-Forwarded-For chain
- Ensure that the final hop matches the REMOTE_ADDR environment variable
- Require deployments to specify a single source for the client IP