### PR TITLE
Set REMOTE_ADDR from X-Forwarded-For with whitelist

### DIFF
--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -318,7 +318,6 @@ BANNED_IP_RANGES = [
 
 # then wsgi.py will make sure that request.META['REMOTE_ADDR'] = '<client ip>'. But if <nginx server ip> or <cloudflare ip>
 # fail to match, wsgi.py will return a 400 Bad Request.
-# NOTE: The security of this scheme requires that each trusted proxy verify the REMOTE_ADDR of the proxy that came before it.
 
 TRUSTED_PROXIES = []
 

--- a/perma_web/perma/settings/deployments/settings_common.py
+++ b/perma_web/perma/settings/deployments/settings_common.py
@@ -304,7 +304,7 @@ BANNED_IP_RANGES = [
 
 # Proxy whitelisting:
 # If TRUSTED_PROXIES is set, wsgi.py will validate that requests come through these proxies,
-# and then set request.META['REMOTE_ATTR'] to match the client IP that comes before the trusted proxy chain in the
+# and then set request.META['REMOTE_ADDR'] to match the client IP that comes before the trusted proxy chain in the
 # X-Forwarded-For header.
 # TRUSTED_PROXIES should be a list of reverse proxies in the chain, where each proxy is a whitelist of IP ranges
 # for that proxy. Proxies should be in order from client to server. For example, given:

--- a/perma_web/perma/tests/test_utils.py
+++ b/perma_web/perma/tests/test_utils.py
@@ -1,4 +1,3 @@
-from django.test import override_settings
 from django.test.client import RequestFactory
 
 from perma.utils import *
@@ -10,47 +9,6 @@ class UtilsTestCase(PermaTestCase):
     def setUp(self):
         self.factory = RequestFactory()
 
-    @override_settings(LIMIT_TO_TRUSTED_PROXY=True,
-                   TRUSTED_PROXIES = ["10.0.2.2"],
-                   TRUSTED_PROXY_HEADER = 'REMOTE_ADDR')
-    def test_get_client_ip_wrong_proxy(self):
-        request = self.factory.get('/some/route', REMOTE_ADDR="127.0.0.1")
-        with self.assertRaises(PermissionDenied):
-            get_client_ip(request)
-
-    @override_settings(LIMIT_TO_TRUSTED_PROXY=True,
-                   TRUSTED_PROXIES = ["10.0.2.2"],
-                   TRUSTED_PROXY_HEADER = 'REMOTE_ADDR')
-    def test_get_client_ip_right_proxy(self):
-        request = self.factory.get('/some/route', REMOTE_ADDR="10.0.2.2")
-        self.assertEqual(get_client_ip(request), "10.0.2.2")
-
-    @override_settings(LIMIT_TO_TRUSTED_PROXY=True,
-                   TRUSTED_PROXIES = ["10.0.2.2"],
-                   TRUSTED_PROXY_HEADER = 'REMOTE_ADDR')
-    def test_get_client_ip_wrong_header(self):
-        request = self.factory.get('/some/route', HTTP_X_FORWARDED_FOR="10.0.2.2")
-        with self.assertRaises(PermissionDenied):
-            get_client_ip(request)
-
-    @override_settings(LIMIT_TO_TRUSTED_PROXY=False,
-                   TRUSTED_PROXIES = ["10.0.2.2"],
-                   TRUSTED_PROXY_HEADER = 'REMOTE_ADDR')
-    def test_get_client_ip_no_checking_remote_only(self):
-        request = self.factory.get('/some/route', REMOTE_ADDR="127.0.0.1")
-        self.assertEqual(get_client_ip(request), "127.0.0.1")
-
-    @override_settings(LIMIT_TO_TRUSTED_PROXY=False,
-                   TRUSTED_PROXIES = ["10.0.2.2"],
-                   TRUSTED_PROXY_HEADER = 'REMOTE_ADDR')
-    def test_get_client_ip_no_checking_xforwarded_only(self):
-        request = self.factory.get('/some/route', HTTP_X_FORWARDED_FOR="127.0.0.1")
-        self.assertEqual(get_client_ip(request), "127.0.0.1")
-
-    @override_settings(LIMIT_TO_TRUSTED_PROXY=False,
-                   TRUSTED_PROXIES = ["10.0.2.2"],
-                   TRUSTED_PROXY_HEADER = 'REMOTE_ADDR')
-    def test_get_client_ip_no_checking_xforwarded_prefered(self):
-        request = self.factory.get('/some/route', HTTP_X_FORWARDED_FOR="10.0.2.2", REMOTE_ADDR="127.0.0.1")
-        self.assertEqual(get_client_ip(request), "10.0.2.2")
-
+    def test_get_client_ip(self):
+        request = self.factory.get('/some/route', REMOTE_ADDR="1.2.3.4")
+        self.assertEqual(get_client_ip(request), "1.2.3.4")

--- a/perma_web/perma/tests/test_wsgi.py
+++ b/perma_web/perma/tests/test_wsgi.py
@@ -1,0 +1,52 @@
+import requests
+
+from django.test import LiveServerTestCase
+
+import perma.settings
+import perma.wsgi
+
+
+class WsgiTestCase(LiveServerTestCase):
+
+    def setUp(self):
+        # Set custom settings and reload wsgi app.
+        # We have to override settings in this weird way -- by monkeypatching perma.settings and reloading wsgi.py --
+        # because wsgi.py is designed to run before django is loaded.
+        self.orig_TRUSTED_PROXIES = perma.settings.TRUSTED_PROXIES
+        perma.settings.TRUSTED_PROXIES = [["1.2.0.0/16", "3.4.0.0/16"],["127.0.0.1"]]
+        reload(perma.wsgi)
+
+        # use full wsgi app in test server
+        self.server_thread.httpd.set_app(self.server_thread.static_handler(perma.wsgi.application))
+
+    def tearDown(self):
+        # Make sure we leave everything like we found it.
+        perma.settings.TRUSTED_PROXIES = self.orig_TRUSTED_PROXIES
+        reload(perma.wsgi)
+
+    def test_get_client_ip_no_proxy(self):
+        # No X-Forwarded-For header:
+        response = requests.get(self.live_server_url)
+        self.assertEqual(response.status_code, 400)
+
+    def test_get_client_ip_short_proxy(self):
+        # Incomplete proxy chain:
+        response = requests.get(self.live_server_url, headers={
+            'X-Forwarded-For': '1.1.1.1'  #<client IP>
+        })
+        self.assertEqual(response.status_code, 400)
+
+    def test_get_client_ip_wrong_proxy(self):
+        # Complete proxy chain, but proxy is wrong:
+        response = requests.get(self.live_server_url, headers={
+            'X-Forwarded-For': '1.1.1.1,8.8.8.8'  #<client IP>,<wrong IP>
+        })
+        self.assertEqual(response.status_code, 400)
+
+    def test_get_client_ip_right_proxy(self):
+        # Valid proxy chain:
+        response = requests.get(self.live_server_url+'/tests/client_ip', headers={
+            'X-Forwarded-For': '1.1.1.1,1.2.3.4'  #<client IP>,<right IP>
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.text, '1.1.1.1')

--- a/perma_web/perma/tests/views.py
+++ b/perma_web/perma/tests/views.py
@@ -1,0 +1,8 @@
+# Views that only load when we are running tests:
+
+from django.http import HttpResponse
+from perma.utils import get_client_ip
+
+
+def client_ip(request):
+    return HttpResponse(get_client_ip(request))

--- a/perma_web/perma/urls.py
+++ b/perma_web/perma/urls.py
@@ -138,3 +138,10 @@ urlpatterns = [
 # debug-only serving of media assets
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+# views that only load when running our tests:
+if settings.TESTING:
+    import tests.views
+    urlpatterns += [
+        url(r'tests/client_ip$', tests.views.client_ip)
+    ]

--- a/perma_web/perma/utils.py
+++ b/perma_web/perma/utils.py
@@ -233,13 +233,4 @@ def url_in_allowed_ip_range(url):
     return ip_in_allowed_ip_range(ip)
 
 def get_client_ip(request):
-    if settings.LIMIT_TO_TRUSTED_PROXY:
-        proxy_ip = IPAddress(request.META['REMOTE_ADDR'])
-        if any(proxy_ip in IPNetwork(trusted_ip_range) for trusted_ip_range in settings.TRUSTED_PROXIES):
-            try:
-                return request.META[settings.TRUSTED_PROXY_HEADER]
-            except KeyError:
-                raise PermissionDenied
-        raise PermissionDenied
-    else:
-        return request.META.get('HTTP_X_FORWARDED_FOR', request.META['REMOTE_ADDR'])
+    return request.META[settings.CLIENT_IP_HEADER]


### PR DESCRIPTION
Here's an approach where wsgi middleware sets REMOTE_ADDR to the true remote address fetched from X-Forwarded-For, by peeling off whitelisted proxy IPs from the right side of the X-Forwarded-For list. (See the notes in settings_common.py for hopefully-useful documentation.)

Advantages of this strategy:
- works across any combination of Cloudflare, Heroku, and Nginx, which suggests it's a good general approach for any deployment behind typical remote proxies.
- works for any naive Django packages that might assume REMOTE_ADDR is always right instead of using our get_ip wrapper.

I had to jump through a bunch of hoops to add testing, but it seems to work, and lays out a path for testing other wsgi-level shenanigans.